### PR TITLE
Add aircon control module and selection menu

### DIFF
--- a/aircon-controller/include/secrets-example.h
+++ b/aircon-controller/include/secrets-example.h
@@ -1,0 +1,9 @@
+// Wi-Fi
+#define WIFI_SSID "my-wifi"
+#define WIFI_PASSWORD "my-wifi-password"
+
+// MQTT
+#define MQTT_SERVER "1234567890.s2.eu.hivemq.cloud"
+#define MQTT_PORT 8883
+#define MQTT_USERNAME "mqtt-username"
+#define MQTT_PASSWORD "mqtt-password"

--- a/aircon-controller/platformio.ini
+++ b/aircon-controller/platformio.ini
@@ -1,0 +1,9 @@
+[env:esp32dev]
+platform = espressif32
+board = esp32dev
+framework = arduino
+monitor_speed = 115200
+lib_deps =
+  knolleary/PubSubClient@^2.8
+  bblanchon/ArduinoJson@^7.0.4
+  crankyoldgit/IRremoteESP8266@^2.8.6

--- a/aircon-controller/src/main.cpp
+++ b/aircon-controller/src/main.cpp
@@ -1,0 +1,82 @@
+#include <Arduino.h>
+#include <WiFi.h>
+#include <WiFiClientSecure.h>
+#include <PubSubClient.h>
+#include <ArduinoJson.h>
+#include <IRremoteESP8266.h>
+#include <IRsend.h>
+#include <ir_Mitsubishi.h>
+#include <secrets.h>
+
+const char* ssid = WIFI_SSID;
+const char* password = WIFI_PASSWORD;
+
+const char* mqtt_server = MQTT_SERVER;
+const int mqtt_port = MQTT_PORT;
+const char* mqtt_user = MQTT_USERNAME;
+const char* mqtt_pass = MQTT_PASSWORD;
+
+const char* mqtt_topic = "mitsubishi-aircon/control";
+
+WiFiClientSecure wifiClient;
+PubSubClient client(wifiClient);
+
+const uint16_t kIrLedPin = 4;
+IRMitsubishiAC ac(kIrLedPin);
+
+void connectWiFi() {
+  WiFi.begin(ssid, password);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(1000);
+  }
+}
+
+void connectMQTT() {
+  while (!client.connected()) {
+    if (client.connect("esp32-aircon", mqtt_user, mqtt_pass)) {
+      client.subscribe(mqtt_topic);
+    } else {
+      delay(1000);
+    }
+  }
+}
+
+void sendAirconCommand(const char* cmd) {
+  ac.setFan(kMitsubishiAcFanAuto);
+  ac.setMode(kMitsubishiAcCool);
+  ac.setTemp(24);
+  if (String(cmd) == "ON") {
+    ac.on();
+  } else if (String(cmd) == "OFF") {
+    ac.off();
+  }
+  ac.send();
+}
+
+void callback(char* topic, byte* payload, unsigned int length) {
+  String message;
+  for (unsigned int i = 0; i < length; i++) message += (char)payload[i];
+  JsonDocument doc;
+  DeserializationError error = deserializeJson(doc, message);
+  if (error) {
+    return;
+  }
+  const char* cmd = doc["message"];
+  sendAirconCommand(cmd);
+}
+
+void setup() {
+  Serial.begin(115200);
+  wifiClient.setInsecure();
+  connectWiFi();
+  client.setServer(mqtt_server, mqtt_port);
+  client.setCallback(callback);
+  ac.begin();
+}
+
+void loop() {
+  if (!client.connected()) {
+    connectMQTT();
+  }
+  client.loop();
+}

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,9 +1,11 @@
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import Login from "./pages/Login";
-import Control from "./pages/Control";
+import Menu from "./pages/Menu";
+import IrrigationControl from "./pages/IrrigationControl";
+import AirconControl from "./pages/AirconControl";
 import ProtectedRoute from "./pages/ProtectedRoute";
 import { ThemeProvider } from "@/components/theme-provider";
-import { Toaster, toast } from "sonner";
+import { Toaster } from "sonner";
 
 function App() {
   return (
@@ -22,14 +24,9 @@ function App() {
         <Routes>
           <Route index element={<Navigate to="/login" replace />} />
           <Route path="/login" element={<Login />} />
-          <Route
-            path="/control"
-            element={
-              <ProtectedRoute>
-                <Control />
-              </ProtectedRoute>
-            }
-          />
+          <Route path="/menu" element={<ProtectedRoute><Menu /></ProtectedRoute>} />
+          <Route path="/irrigation" element={<ProtectedRoute><IrrigationControl /></ProtectedRoute>} />
+          <Route path="/aircon" element={<ProtectedRoute><AirconControl /></ProtectedRoute>} />
         </Routes>
       </BrowserRouter>
     </ThemeProvider>

--- a/client/src/components/ConfigItem.tsx
+++ b/client/src/components/ConfigItem.tsx
@@ -15,11 +15,9 @@ import { useMqttClient } from "./hooks/useMqttClient";
 import {
   SWITCH_MIN_OPEN_DURATION,
   SWITCH_MAX_OPEN_DURATION,
-  CONTROLLER_DEVICE_ID_TO_TOPIC,
   HEARTBEAT_INTERVAL_MIN,
   HEARTBEAT_INTERVAL_MAX,
 } from "@/constants";
-import { formatTopicFromTopicString } from "@/utils";
 
 export default function ConfigItem(props: {
   client: MqttClient | null;
@@ -90,11 +88,6 @@ export default function ConfigItem(props: {
   const displayedHighDuration = useMemo(
     () => (highDuration / 1000).toFixed(1),
     [highDuration]
-  );
-
-  const formattedTopicString: string = useMemo(
-    () => formatTopicFromTopicString(topicItem),
-    [CONTROLLER_DEVICE_ID_TO_TOPIC, topicItem]
   );
 
   return (

--- a/client/src/components/ControlItem.tsx
+++ b/client/src/components/ControlItem.tsx
@@ -8,7 +8,7 @@ import {
   mqttMessage,
   mqttHealthMessage,
 } from "../types";
-import { enumClientStatus } from "../pages/Control";
+import { enumClientStatus } from "../types";
 import {
   getEnumKeyByEnumValue,
   dateFormatter,

--- a/client/src/components/ControlLayout.tsx
+++ b/client/src/components/ControlLayout.tsx
@@ -1,0 +1,26 @@
+import { ReactNode } from "react";
+import { useNavigate } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { ArrowLeft } from "lucide-react";
+
+interface ControlLayoutProps {
+  children: ReactNode;
+  rightSlot?: ReactNode;
+}
+
+export default function ControlLayout({ children, rightSlot }: ControlLayoutProps) {
+  const navigate = useNavigate();
+  return (
+    <div className="base relative">
+      <Button
+        variant="ghost"
+        className="absolute left-3 top-3"
+        onClick={() => navigate("/menu")}
+      >
+        <ArrowLeft />
+      </Button>
+      {rightSlot && <div className="absolute right-3 top-3">{rightSlot}</div>}
+      {children}
+    </div>
+  );
+}

--- a/client/src/components/hooks/useMqttClient.tsx
+++ b/client/src/components/hooks/useMqttClient.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { MqttClient } from "mqtt";
-import { enumClientStatus } from "@/pages/Control";
+import { enumClientStatus } from "@/types";
 import { mqttMessage } from "@/types";
 
 interface UseMQTTListenerProps {

--- a/client/src/components/ui/accordion.tsx
+++ b/client/src/components/ui/accordion.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import * as AccordionPrimitive from "@radix-ui/react-accordion";
-import { ChevronDownIcon } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -11,3 +11,5 @@ export const CONTROLLER_DEVICE_ID_TO_TOPIC: Record<string, topicList> = {
   "esp32-E6D7": { topic: "water-monsiis", quantity: 2 },
   "esp32-77EE": { topic: "avii-moss", quantity: 1 },
 };
+
+export const AIRCON_MQTT_TOPIC = "mitsubishi-aircon/control";

--- a/client/src/pages/AirconControl.tsx
+++ b/client/src/pages/AirconControl.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from "react";
+import mqtt, { MqttClient } from "mqtt";
+import Logo from "@/components/Logo";
+import { Button } from "@/components/ui/button";
+import { LoaderCircle } from "lucide-react";
+import ControlLayout from "@/components/ControlLayout";
+import { useMqttClient } from "@/components/hooks/useMqttClient";
+import { enumClientStatus, mqttMessage } from "../types";
+import { AIRCON_MQTT_TOPIC } from "../constants";
+
+export default function AirconControl() {
+  const [client, setClient] = useState<MqttClient | null>(null);
+  const { clientStatus } = useMqttClient({ mqttClient: client });
+
+  useEffect(() => {
+    const mqttClient = mqtt.connect(import.meta.env.VITE_MQTT_CLUSTER_URL, {
+      username: import.meta.env.VITE_MQTT_USERNAME,
+      password: import.meta.env.VITE_MQTT_PASSWORD,
+    });
+    setClient(mqttClient);
+  }, []);
+
+  const sendCommand = (cmd: string) => {
+    if (!client) return;
+    const message: mqttMessage = {
+      message: cmd,
+      timestamp: new Date().toISOString(),
+    };
+    client.publish(AIRCON_MQTT_TOPIC, JSON.stringify(message), { retain: true });
+  };
+
+  return (
+    <ControlLayout>
+      <div className="flex flex-col items-center justify-center max-w-xl -mt-5">
+        <Logo />
+        <div className="mb-4 w-full max-w-xl flex justify-center items-center gap-2">
+          {clientStatus === enumClientStatus.CONNECTED ||
+          clientStatus === enumClientStatus.RECONNECTED ? (
+            "✅"
+          ) : (
+            <LoaderCircle className="animate-spin text-foreground" />
+          )}
+          <p className="sm:text-lg">
+            {clientStatus === enumClientStatus.CONNECTED ||
+            clientStatus === enumClientStatus.RECONNECTED
+              ? "Connected to MQTT broker"
+              : "Connecting to MQTT..."}
+          </p>
+        </div>
+        <div className="flex gap-4">
+          <Button onClick={() => sendCommand("ON")}>Turn On</Button>
+          <Button onClick={() => sendCommand("OFF")} variant="destructive">
+            Turn Off
+          </Button>
+        </div>
+      </div>
+    </ControlLayout>
+  );
+}

--- a/client/src/pages/IrrigationControl.tsx
+++ b/client/src/pages/IrrigationControl.tsx
@@ -3,9 +3,10 @@ import mqtt, { MqttClient } from "mqtt";
 import ControlItem from "../components/ControlItem";
 import Logo from "@/components/Logo";
 import { CONTROLLER_DEVICE_ID_TO_TOPIC } from "../constants";
-import { mqttTopicItem } from "../types";
+import { mqttTopicItem, enumClientStatus } from "../types";
 import { getArrayOfTopicItems } from "../utils";
 import { LoaderCircle, Bolt } from "lucide-react";
+import ControlLayout from "@/components/ControlLayout";
 import { useMqttClient } from "@/components/hooks/useMqttClient";
 import {
   Dialog,
@@ -17,14 +18,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 
-export enum enumClientStatus {
-  CONNECTED = "Connected",
-  ERROR = "Error",
-  RECONNECTED = "Reconnected",
-  CLOSED = "Closed",
-}
-
-export default function Control() {
+export default function IrrigationControl() {
   const [client, setClient] = useState<MqttClient | null>(null);
   const { clientStatus } = useMqttClient({ mqttClient: client });
   const [showHighDuration, setShowHighDuration] = useState<boolean>(false); //minutes
@@ -43,33 +37,36 @@ export default function Control() {
     [CONTROLLER_DEVICE_ID_TO_TOPIC]
   );
 
-  return (
-    <div className="base relative">
-      <Dialog>
-        <DialogTrigger asChild>
-          <Button variant={"ghost"} className="absolute right-3">
-            <Bolt />
-          </Button>
-        </DialogTrigger>
-        <DialogContent className="max-w-xs md:max-w-sm">
-          <DialogHeader>
-            <DialogTitle className="text-left">Main Config</DialogTitle>
-          </DialogHeader>
-          <div className="flex flex-col items-stretch justify-between gap-6 mt-4">
-            <div className="flex justify-between items-center">
-              <p>Show HIGH duration config</p>
-              <div className="flex items-center justify-center text-center">
-                <Switch
-                  checked={showHighDuration}
-                  onCheckedChange={(checked: boolean) =>
-                    setShowHighDuration(checked)
-                  }
-                />
-              </div>
+  const configDialog = (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button variant={"ghost"}>
+          <Bolt />
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-xs md:max-w-sm">
+        <DialogHeader>
+          <DialogTitle className="text-left">Main Config</DialogTitle>
+        </DialogHeader>
+        <div className="flex flex-col items-stretch justify-between gap-6 mt-4">
+          <div className="flex justify-between items-center">
+            <p>Show HIGH duration config</p>
+            <div className="flex items-center justify-center text-center">
+              <Switch
+                checked={showHighDuration}
+                onCheckedChange={(checked: boolean) =>
+                  setShowHighDuration(checked)
+                }
+              />
             </div>
           </div>
-        </DialogContent>
-      </Dialog>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+
+  return (
+    <ControlLayout rightSlot={configDialog}>
       <div className="mt-42">
         <Logo />
       </div>
@@ -105,6 +102,6 @@ export default function Control() {
           ))}
         </div>
       </div>
-    </div>
+    </ControlLayout>
   );
 }

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -20,14 +20,14 @@ export default function Login() {
         { token },
         { withCredentials: true }
       );
-      navigate("/control");
+      navigate("/menu");
       setIsLoading(false);
-    } catch (err: any) {
+    } catch (err) {
       console.log(err);
-      if (err.response) {
+      if (axios.isAxiosError(err) && err.response) {
         const message: string = `${err.response.status}: ${err.response.statusText}`;
         toast.error(message);
-      } else {
+      } else if (err instanceof Error) {
         toast.error(err.message);
       }
 

--- a/client/src/pages/Menu.tsx
+++ b/client/src/pages/Menu.tsx
@@ -1,0 +1,16 @@
+import { Button } from "@/components/ui/button";
+import Logo from "@/components/Logo";
+import { useNavigate } from "react-router-dom";
+
+export default function Menu() {
+  const navigate = useNavigate();
+  return (
+    <div className="base justify-center max-w-xl -mt-5">
+      <Logo />
+      <div className="flex flex-col gap-4 mt-8">
+        <Button onClick={() => navigate("/irrigation")}>Irrigation Control</Button>
+        <Button onClick={() => navigate("/aircon")}>Aircon Control</Button>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/ProtectedRoute.tsx
+++ b/client/src/pages/ProtectedRoute.tsx
@@ -3,7 +3,7 @@ import { Navigate } from 'react-router-dom';
 import axios from 'axios';
 
 export default function ProtectedRoute(props: { children:ReactNode }) {
-  const [authenticated, setAuthenticated] = useState<Boolean | null>(null);
+  const [authenticated, setAuthenticated] = useState<boolean | null>(null);
 
   useEffect(() => {
     axios.get(`${import.meta.env.VITE_BACKEND_URL}/auth/check`, { withCredentials: true })

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -1,5 +1,12 @@
 export type mqttTopicItem = `${string}/${number}`;
 
+export enum enumClientStatus {
+  CONNECTED = "Connected",
+  ERROR = "Error",
+  RECONNECTED = "Reconnected",
+  CLOSED = "Closed",
+}
+
 export const makeMqttTopicItem = (
   topicCategory: string,
   index: number


### PR DESCRIPTION
## Summary
- add post-login menu to choose irrigation or aircon modules
- implement aircon control page publishing MQTT IR commands
- include ESP32 sample for Mitsubishi aircon IR via MQTT
- refactor irrigation and aircon pages to use a shared layout with back navigation

## Testing
- `npm run lint`
- `npm run build`
- `pio run` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio)*

------
https://chatgpt.com/codex/tasks/task_e_68958b41a9408323962ae6837cbcb7c9