### PR TITLE
docs: add architecture overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,121 @@
 # ESP32-MQTT-control
-Control of ESP32 microcontroller via MQTT using web app.
+
+Control of ESP32 microcontrollers via MQTT using a web app and Node.js backend.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    subgraph Web
+        C[Web App]
+    end
+    subgraph Backend
+        S[Server]
+    end
+    subgraph Broker
+        B[(MQTT Broker)]
+    end
+    subgraph Devices
+        E[ESP32 Controllers]
+    end
+    subgraph Storage
+        DB[(PostgreSQL)]
+    end
+
+    C -->|HTTP/WebSocket| S
+    S -->|SQL| DB
+    S <--> |MQTT| B
+    B <--> E
+```
+
+### Irrigation controller
+
+```mermaid
+sequenceDiagram
+    participant Web
+    participant Server
+    participant Broker
+    participant ESP32 as ESP32 Irrigation Controller
+
+    Web->>Server: control / config
+    Server->>Broker: publish command
+    Broker->>ESP32: deliver command
+    ESP32->>Broker: status / health
+    Broker->>Server: relay status
+```
+
+#### MQTT message schema
+
+Commands and telemetry for the irrigation controller are published to topics
+such as `irrigation/<id>/control` or `irrigation/<id>/status`. The MQTT topic is
+part of the message envelope handled by the broker and **is not included in the
+JSON payload**. Each payload is a JSON object with the following fields:
+
+| Field | Type | Description | Example |
+|-------|------|-------------|---------|
+| `message` | string or object | Payload specific to the topic. See below for irrigation message formats. | `"HIGH"` |
+| `timestamp` | string (ISO 8601) | When the sender generated the message. | `2024-01-01T12:00:00.123Z` |
+
+##### Control / status topics (`irrigation/<id>/control`, `irrigation/<id>/status`)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `message` | string | `"HIGH"` to open the valve, `"LOW"` to close it. |
+
+Publish to `irrigation/<id>/control` with payload:
+
+```json
+{
+  "message": "HIGH",
+  "timestamp": "2024-01-01T12:00:00.123Z"
+}
+```
+
+##### Config topic (`irrigation/<id>/config`)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `message.highDuration` | number (ms) | Duration the valve stays open; firmware clamps to safe bounds. |
+| `message.heartbeatInterval` | number (minutes) | Interval between controller health pings. |
+
+Publish to `irrigation/<id>/config` with payload:
+
+```json
+{
+  "message": {
+    "highDuration": 3000,
+    "heartbeatInterval": 5
+  },
+  "timestamp": "2024-01-01T12:00:00.123Z"
+}
+```
+
+##### Health topic (`irrigation/<id>/controllerhealth`)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `message.ipAddress` | string | Current IP address reported by the controller. |
+
+Publish to `irrigation/<id>/controllerhealth` with payload:
+
+```json
+{
+  "message": {
+    "ipAddress": "192.168.1.100"
+  },
+  "timestamp": "2024-01-01T12:00:00.123Z"
+}
+```
+## Database schema
+
+```mermaid
+erDiagram
+    EVENTS {
+        uuid id
+        string event_type
+        jsonb payload
+    }
+```
 
 ## Server logging
 


### PR DESCRIPTION
## Summary
- document system architecture with a mermaid diagram showing web app, server, MQTT broker, devices, and database
- describe event table structure with an ER diagram
- detail irrigation MQTT message schema for control, config, and health topics, including topic strings and JSON examples

## Testing
- `npm test` (server) *(fails: Missing script "test")*
- `npm test` (client) *(fails: Missing script "test")*
- `pio test` *(fails: command not found: pio)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b9cfc8ac8323baa71f58bd336d6a