### PR TITLE
Use device/component topic pattern for aircon controller

### DIFF
--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -1,4 +1,4 @@
-import { topicList } from "./types";
+import { topicList, enumMqttTopicType } from "./types";
 
 export const SWITCH_MIN_OPEN_DURATION = 500; //miileseconds
 export const SWITCH_MAX_OPEN_DURATION = 60000;
@@ -12,4 +12,6 @@ export const CONTROLLER_DEVICE_ID_TO_TOPIC: Record<string, topicList> = {
   "esp32-77EE": { topic: "avii-moss", quantity: 1 },
 };
 
-export const AIRCON_MQTT_TOPIC = "mitsubishi-aircon/control";
+export const AIRCON_DEVICE_ID = "mitsubishi-aircon";
+export const AIRCON_COMPONENT_INDEX = 1;
+export const AIRCON_MQTT_TOPIC = `${AIRCON_DEVICE_ID}/${AIRCON_COMPONENT_INDEX}/${enumMqttTopicType.CONTROL}`;


### PR DESCRIPTION
## Summary
- Assign a unique deviceId and component index to the aircon controller
- Subscribe to `deviceId/component/control` topic pattern for aircon commands
- Expose matching constants in the client to publish to the new topic format

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `platformio run` *(fails: command not found: platformio)*

------
https://chatgpt.com/codex/tasks/task_e_68b7a945ad888323953459bb1400a764