### PR TITLE
feat: add typed MQTT message union

### DIFF
--- a/client/src/components/hooks/useMqttClient.tsx
+++ b/client/src/components/hooks/useMqttClient.tsx
@@ -1,12 +1,15 @@
 import { useEffect, useState } from "react";
 import { MqttClient } from "mqtt";
-import { enumClientStatus } from "@/types";
-import { mqttMessage } from "@/types";
+import {
+  enumClientStatus,
+  enumMqttTopicType,
+  MqttMessageAny,
+} from "@/types";
 
 interface UseMQTTListenerProps {
   mqttClient: MqttClient | null;
   topics?: string[];
-  onMessage?: (topic: string, payload: mqttMessage) => void;
+  onMessage?: (topic: string, payload: MqttMessageAny) => void;
 }
 
 export const useMqttClient = ({
@@ -50,8 +53,17 @@ export const useMqttClient = ({
 
     const handleMessage = (topic: string, payload: Buffer<ArrayBufferLike>) => {
       if (topics?.includes(topic) && onMessage) {
-        const payloadObject: mqttMessage = JSON.parse(payload.toString());
-        onMessage(topic, payloadObject);
+        const parsed = JSON.parse(payload.toString()) as MqttMessageAny;
+        switch (parsed.type) {
+          case enumMqttTopicType.STATUS:
+          case enumMqttTopicType.CONFIG:
+          case enumMqttTopicType.HEALTH:
+          case enumMqttTopicType.CONTROL:
+            onMessage(topic, parsed);
+            break;
+          default:
+            console.warn(`Unhandled MQTT message type: ${parsed.type}`);
+        }
       }
     };
 

--- a/client/src/pages/AirconControl.tsx
+++ b/client/src/pages/AirconControl.tsx
@@ -5,7 +5,11 @@ import { Button } from "@/components/ui/button";
 import { LoaderCircle } from "lucide-react";
 import ControlLayout from "@/components/ControlLayout";
 import { useMqttClient } from "@/components/hooks/useMqttClient";
-import { enumClientStatus, mqttMessage } from "../types";
+import {
+  enumClientStatus,
+  enumMqttTopicType,
+  MqttControlMessage,
+} from "../types";
 import { AIRCON_MQTT_TOPIC } from "../constants";
 
 export default function AirconControl() {
@@ -22,7 +26,8 @@ export default function AirconControl() {
 
   const sendCommand = (cmd: string) => {
     if (!client) return;
-    const message: mqttMessage = {
+    const message: MqttControlMessage = {
+      type: enumMqttTopicType.CONTROL,
       message: cmd,
       timestamp: new Date().toISOString(),
     };

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -31,10 +31,33 @@ export const getMqttTopicId = (
 export type mqttTopicId = `${mqttTopicItem}/${enumMqttTopicType}`;
 // const id: mqttTopicId = 'irrigation/1/control';
 
-export type mqttMessage = {
-  message: string | mqttConfigMessage | mqttHealthMessage;
+export interface MqttMessage<T> {
+  type: enumMqttTopicType;
+  message: T;
   timestamp: string;
-};
+}
+
+export interface MqttStatusMessage extends MqttMessage<string> {
+  type: enumMqttTopicType.STATUS;
+}
+
+export interface MqttConfigMessage extends MqttMessage<mqttConfigMessage> {
+  type: enumMqttTopicType.CONFIG;
+}
+
+export interface MqttHealthMessage extends MqttMessage<mqttHealthMessage> {
+  type: enumMqttTopicType.HEALTH;
+}
+
+export interface MqttControlMessage extends MqttMessage<string> {
+  type: enumMqttTopicType.CONTROL;
+}
+
+export type MqttMessageAny =
+  | MqttStatusMessage
+  | MqttConfigMessage
+  | MqttHealthMessage
+  | MqttControlMessage;
 
 export type mqttConfigMessage = {
   highDuration?: number;


### PR DESCRIPTION
## Summary
- define discriminated `MqttMessage` interface and message variants
- parse and dispatch typed MQTT messages in `useMqttClient`
- refactor components to switch on message type and include type when publishing
- add `MqttControlMessage` and rename union to `MqttMessageAny`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7b1d147d88323bf11d6b8ae450321