### PR TITLE
feat(server): accept deploy frontend URL in CORS

### DIFF
--- a/server/.env-example
+++ b/server/.env-example
@@ -1,3 +1,4 @@
 FRONTEND_URL=https://my-front-end.com
+FRONTEND_URL_DEPLOY=https://my-deploy-front-end.com
 SHARED_TOKEN=my-token
 COOKIE_NAME=my-cookie

--- a/server/api/index.js
+++ b/server/api/index.js
@@ -7,11 +7,16 @@ const app = express();
 // const PORT = 4000;
 const SESSION_TTL_MS = 1000 * 60 * 60 * 24; // 1 day
 
+const allowedOrigins = [
+  process.env.FRONTEND_URL,
+  process.env.FRONTEND_URL_DEPLOY,
+].filter(Boolean);
+
 app.use(express.json());
 app.use(cookieParser());
 app.use(
   cors({
-    origin: process.env.FRONTEND_URL, // Vite frontend
+    origin: allowedOrigins, // Vite frontend and deploy branch
     credentials: true,
   })
 );


### PR DESCRIPTION
## Summary
- allow server CORS to accept an additional `FRONTEND_URL_DEPLOY`
- document `FRONTEND_URL_DEPLOY` in `.env-example`

## Testing
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68b7b690da0c8323972f2a416485ae8c