### PR TITLE
refactor: add discriminated config messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,15 +75,28 @@ Publish to `irrigation/<id>/control` with payload:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `message.highDuration` | number (ms) | Duration the valve stays open; firmware clamps to safe bounds. |
-| `message.heartbeatInterval` | number (minutes) | Interval between controller health pings. |
+| `message.configType` | string | "highDuration" or "heartbeatInterval" to indicate which setting is being updated. |
+| `message.highDuration` | number (ms) | Present when `configType` is `highDuration`; duration the valve stays open. |
+| `message.heartbeatInterval` | number (minutes) | Present when `configType` is `heartbeatInterval`; interval between controller health pings. |
 
 Publish to `irrigation/<id>/config` with payload:
 
 ```json
 {
   "message": {
-    "highDuration": 3000,
+    "configType": "highDuration",
+    "highDuration": 3000
+  },
+  "timestamp": "2024-01-01T12:00:00.123Z"
+}
+```
+
+or
+
+```json
+{
+  "message": {
+    "configType": "heartbeatInterval",
     "heartbeatInterval": 5
   },
   "timestamp": "2024-01-01T12:00:00.123Z"

--- a/client/src/components/ConfigItem.tsx
+++ b/client/src/components/ConfigItem.tsx
@@ -37,10 +37,18 @@ export default function ConfigItem(props: {
   const onMessageReceived = (_topic: string, payload: MqttMessageAny) => {
     switch (payload.type) {
       case enumMqttTopicType.CONFIG:
-        if (payload.message.highDuration !== undefined)
-          setHighDuration(payload.message.highDuration);
-        if (payload.message.heartbeatInterval !== undefined)
-          setHeartbeatIntervalDuration(payload.message.heartbeatInterval);
+        switch (payload.message.configType) {
+          case "highDuration":
+            setHighDuration(payload.message.highDuration);
+            break;
+          case "heartbeatInterval":
+            setHeartbeatIntervalDuration(
+              payload.message.heartbeatInterval
+            );
+            break;
+          default:
+            break;
+        }
         break;
       default:
         break;
@@ -53,10 +61,15 @@ export default function ConfigItem(props: {
     onMessage: onMessageReceived,
   });
 
+  const displayedHighDuration = useMemo(
+    () => (highDuration / 1000).toFixed(1),
+    [highDuration]
+  );
+
   const onHighDurationCommit = useCallback(() => {
     const message: MqttConfigMessage = {
       type: enumMqttTopicType.CONFIG,
-      message: { highDuration },
+      message: { configType: "highDuration", highDuration },
       timestamp: new Date().toISOString(),
     };
     console.log("message to publish: ", topicConfig, message);
@@ -71,7 +84,10 @@ export default function ConfigItem(props: {
   const onHeartbeatIntervalCommit = useCallback(() => {
     const message: MqttConfigMessage = {
       type: enumMqttTopicType.CONFIG,
-      message: { heartbeatInterval: heartbeatIntervalDuration },
+      message: {
+        configType: "heartbeatInterval",
+        heartbeatInterval: heartbeatIntervalDuration,
+      },
       timestamp: new Date().toISOString(),
     };
     console.log("message to publish: ", topicConfig, message);
@@ -82,11 +98,6 @@ export default function ConfigItem(props: {
       description: `Heartbeat interval updated to ${heartbeatIntervalDuration} minutes`,
     });
   }, [client, heartbeatIntervalDuration, topicConfig]);
-
-  const displayedHighDuration = useMemo(
-    () => (highDuration / 1000).toFixed(1),
-    [highDuration]
-  );
 
   return (
     <div className="flex flex-col items-start justify-center gap-3">

--- a/client/src/components/hooks/useMqttClient.tsx
+++ b/client/src/components/hooks/useMqttClient.tsx
@@ -62,7 +62,7 @@ export const useMqttClient = ({
             onMessage(topic, parsed);
             break;
           default:
-            console.warn(`Unhandled MQTT message type: ${parsed.type}`);
+            console.warn("Unhandled MQTT message type");
         }
       }
     };

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -59,12 +59,19 @@ export type MqttMessageAny =
   | MqttHealthMessage
   | MqttControlMessage;
 
-export type mqttConfigMessage = {
-  highDuration?: number;
-  heartbeatInterval?: number;
-  // add other config properties here in the future
-  // e.g. pressure: number, enabled: boolean, etc.
-};
+export interface HighDurationConfig {
+  configType: "highDuration";
+  highDuration: number;
+}
+
+export interface HeartbeatIntervalConfig {
+  configType: "heartbeatInterval";
+  heartbeatInterval: number;
+}
+
+export type mqttConfigMessage =
+  | HighDurationConfig
+  | HeartbeatIntervalConfig;
 
 export type mqttHealthMessage = {
   ipAddress: string;

--- a/controller/src/main.cpp
+++ b/controller/src/main.cpp
@@ -344,37 +344,51 @@ void callback(char* topic, byte* payload, unsigned int length) {
       deactivateSwitch(topic_id);
     }
   } else if (String(topic_type) == String(topic_type_config)) {
-    // Check nested structure
-    if (doc["message"]["highDuration"]) {
-      long received_duration = doc["message"]["highDuration"].as<unsigned long>();
-      if (received_duration > valve_max_duration) {
-        Serial.printf("Received valve duration of %lums\n", received_duration);
-        valves[topic_id].durationMs = valve_max_duration;
-      } else if (received_duration < valve_min_duration) {
-        Serial.printf("Received valve duration of %lums\n", received_duration);
-        valves[topic_id].durationMs = valve_min_duration;
-      } else {
-        valves[topic_id].durationMs = received_duration;
-      }
-      Serial.printf("✅ Valve duration for index %i updated to %lums\n", topic_id, valves[topic_id].durationMs);
-    } else {
-      Serial.println("⚠️ JSON missing 'message.highDuration'");
+    const char* configType = doc["message"]["configType"];
+    if (!configType) {
+      Serial.println("⚠️ JSON missing 'message.configType'");
+      return;
     }
 
-    if (doc["message"]["heartbeatInterval"]) {
-      float receivedInterval = doc["message"]["heartbeatInterval"].as<float>();
-      if (receivedInterval > healthInterval_max_duration) {
-        Serial.printf("Received heartbeat interval duration of %fminutes\n", receivedInterval);
-        healthInterval = healthInterval_max_duration;
-      } else if (receivedInterval < healthInterval_min_duration) {
-        Serial.printf("Received heartbeat interval duration of %fminutes\n", receivedInterval);
-        healthInterval = healthInterval_min_duration;
+    if (String(configType) == "highDuration") {
+      if (doc["message"]["highDuration"]) {
+        long received_duration =
+            doc["message"]["highDuration"].as<unsigned long>();
+        if (received_duration > valve_max_duration) {
+          Serial.printf("Received valve duration of %lums\n", received_duration);
+          valves[topic_id].durationMs = valve_max_duration;
+        } else if (received_duration < valve_min_duration) {
+          Serial.printf("Received valve duration of %lums\n", received_duration);
+          valves[topic_id].durationMs = valve_min_duration;
+        } else {
+          valves[topic_id].durationMs = received_duration;
+        }
+        Serial.printf("✅ Valve duration for index %i updated to %lums\n",
+                      topic_id, valves[topic_id].durationMs);
       } else {
-        healthInterval = receivedInterval;
+        Serial.println("⚠️ JSON missing 'message.highDuration'");
       }
-      Serial.printf("✅ Heartbeat interval duration for index %i updated to %fminutes\n", topic_id, healthInterval);
-    } else {
-      Serial.println("⚠️ JSON missing 'message.heartbeatInterval'");
+    } else if (String(configType) == "heartbeatInterval") {
+      if (doc["message"]["heartbeatInterval"]) {
+        float receivedInterval =
+            doc["message"]["heartbeatInterval"].as<float>();
+        if (receivedInterval > healthInterval_max_duration) {
+          Serial.printf("Received heartbeat interval duration of %fminutes\n",
+                        receivedInterval);
+          healthInterval = healthInterval_max_duration;
+        } else if (receivedInterval < healthInterval_min_duration) {
+          Serial.printf("Received heartbeat interval duration of %fminutes\n",
+                        receivedInterval);
+          healthInterval = healthInterval_min_duration;
+        } else {
+          healthInterval = receivedInterval;
+        }
+        Serial.printf(
+            "✅ Heartbeat interval duration for index %i updated to %fminutes\n",
+            topic_id, healthInterval);
+      } else {
+        Serial.println("⚠️ JSON missing 'message.heartbeatInterval'");
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- split configuration commands into `HighDurationConfig` and `HeartbeatIntervalConfig`
- include `configType` field and update publisher/receiver logic
- document new config message format

## Testing
- `npm run lint`
- `npm run build`
- `pio run` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b707419483238529f77e987076e0